### PR TITLE
Update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,18 +44,18 @@ To follow this guide, you need the following:
   npm i -S algoliasearch
 ```
 
-5. In your Catalyst `/components/quick-search` directory, do the following: 
+5. Update the files in your Catalyst `/components/quick-search` directory to include the code from the [Algolia example repo](https://github.com/gje4/catalyst-algolia) `/components/quick-search` directory
    
-  - Add the `algoliaSearchBox.tsx` and `algoliaSearchHits.tsx` files from the [Algolia example repo](https://github.com/gje4/catalyst-algolia) `/components/quick-search` directory
-  - Update the `index.tsx` file to include the code from that of the Algolia example repo
+  - Add the `algoliaSearchBox.tsx` and `algoliaSearchHits.tsx` files
+  - Update the `index.tsx` file
 
 Your storefront's file tree will mirror the following screenshot.
 
 ![A file tree with a components/quick-seach directory that contains the same files as the Algolia example repo](https://storage.googleapis.com/bigcommerce-production-dev-center/images/catalyst/algolia/algolia-integration-file-tree.png)
 
-1. In `components/quick-search/index.tsx`, update the value of `algoliaClient` to use your correct `indexName`. By default, the BigCommerce Algolia app names the search index `BigCommerce`.
+6. In `components/quick-search/index.tsx`, update the value of `algoliaClient` to use your correct `indexName`. By default, the BigCommerce Algolia app names the search index `BigCommerce`.
 
-2.  Start your Catalyst storefront app in dev mode. Check the QuickSearch box to see the data supplied by the Algolia app index.
+7.  Start your Catalyst storefront app in dev mode. Check the QuickSearch box to see the data supplied by the Algolia app index.
 
 ```shell copy
 pnpm run dev

--- a/README.md
+++ b/README.md
@@ -44,22 +44,18 @@ To follow this guide, you need the following:
   npm i -S algoliasearch
 ```
 
-5. Clone the [Algolia example repo](https://github.com/gje4/catalyst-algolia) in a directory parallel to your Catalyst storefront. Copy the `quick-search` directory into your Catalyst `components` directory.
-
-```shell copy
-git clone https://github.com/gje4/catalyst-algolia
-cd catalyst-algolia
-cp components/quick-search ../my-catalyst-storefront/components/quick-search
-cd ../my-catalyst-storefront/components/quick-search
-```
+5. In your Catalyst `/components/quick-search` directory, do the following: 
+   
+  - Add the `algoliaSearchBox.tsx` and `algoliaSearchHits.tsx` files from the [Algolia example repo](https://github.com/gje4/catalyst-algolia) `/components/quick-search` directory
+  - Update the `index.tsx` file to include the code from that of the Algolia example repo
 
 Your storefront's file tree will mirror the following screenshot.
 
-[!A file tree with a components/quick-seach directory that contains the same files as the Algolia example repo](https://storage.googleapis.com/bigcommerce-production-dev-center/images/catalyst/algolia/algolia-integration-file-tree.png)
+![A file tree with a components/quick-seach directory that contains the same files as the Algolia example repo](https://storage.googleapis.com/bigcommerce-production-dev-center/images/catalyst/algolia/algolia-integration-file-tree.png)
 
-6. In `components/quick-search/index.tsx`, update the value of `algoliaClient` to use your correct `indexName`. By default, the BigCommerce Algolia app names the search index `BigCommerce`.
+1. In `components/quick-search/index.tsx`, update the value of `algoliaClient` to use your correct `indexName`. By default, the BigCommerce Algolia app names the search index `BigCommerce`.
 
-7.  Start your Catalyst storefront app in dev mode. Check the QuickSearch box to see the data supplied by the Algolia app index.
+2.  Start your Catalyst storefront app in dev mode. Check the QuickSearch box to see the data supplied by the Algolia app index.
 
 ```shell copy
 pnpm run dev


### PR DESCRIPTION
- Fix image syntax so it renders
- Fix Step 5. Previously, step 5 produced the following screenshot (inaccurate): 

 
![algolia](https://github.com/gje4/catalyst-algolia/assets/96258747/d5c14b72-36e6-49f7-b114-e4dea69acd39)
